### PR TITLE
ci(fix): Use PAT for release-please

### DIFF
--- a/.github/workflows/on-push-main-branch.yaml
+++ b/.github/workflows/on-push-main-branch.yaml
@@ -14,3 +14,4 @@ jobs:
   release-please:
     name: Run release please
     uses: ./.github/workflows/release-please.yaml
+    secrets: inherit

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,6 @@
 name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
-  release: # Trigger when a new release is made.
-    types: [published]
   push:
     tags: [ "v*" ]
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -3,6 +3,10 @@ name: 🔖 Release please
 on:
   workflow_dispatch: # Enable manual triggers.
   workflow_call: # Enables workflow to be called from another workflow.
+    secrets:
+      RELEASE_PLEASE_TOKEN:
+        description: A PAT for the release-please action. Requires 'RW' for 'Pull requests' and 'Contents'.
+        required: true
     outputs:
       release_created:
         description: "If true, a release PR has been merged"
@@ -20,6 +24,7 @@ jobs:
         with:
           release-type: python
           target-branch: main
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
## Description
Allows workflows to trigger on release-please actions (such as new releases/tags) by using a PAT. Necessary for automated releases, as workflows may not be triggered by actions caused by the 'github-actions' bot (see https://github.com/googleapis/release-please-action?tab=readme-ov-file#github-credentials for details).

# Why
To allow automated publish workflow runs (`publish.yaml`) when release-please creates a new tag (release)

# How
*How the change is implemented (if it's not self evident in the diff)*

Close: #

# Checklist:
Before submitting this PR, please make sure:

- [ ] I am complying with the [contributing](https://equinor.github.io/completor/contribution_guide) doc
- [ ] My code builds clean without any errors or warnings
- [ ] I have added/extended tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation, and it builds correctly
