### PR TITLE
ci(fix): Publish to pypi with workflow_call when release-please tag created

### DIFF
--- a/.github/workflows/on-push-main-branch.yaml
+++ b/.github/workflows/on-push-main-branch.yaml
@@ -17,3 +17,4 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write

--- a/.github/workflows/on-push-main-branch.yaml
+++ b/.github/workflows/on-push-main-branch.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
 
-
 jobs:
   check-docs:
     name: Check documentation
@@ -15,3 +14,6 @@ jobs:
     name: Run release please
     uses: ./.github/workflows/release-please.yaml
     secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,10 +1,17 @@
 name: Publish Python 🐍 distributions 📦 to PyPI
-
 on:
-  push:
-    tags: [ "v*" ]
-
-  workflow_dispatch: # Trigger manually.
+  workflow_call:
+    inputs:
+      tag:
+        description: The tag to use for checkout
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The tag to use for checkout
+        required: true
+        type: string
 
 jobs:
   build:
@@ -12,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.tag }}
 
     - name: Install poetry
       run: pipx install poetry==1.8.3
@@ -36,7 +45,6 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # Only publish to PyPI on tag pushes.
     needs:
       - build
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -15,6 +15,10 @@ on:
         description: "The release tag. Ex v1.4.0"
         value: ${{ jobs.release-please.outputs.tag_name }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release_please:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -10,10 +10,10 @@ on:
     outputs:
       release_created:
         description: "If true, a release PR has been merged"
-        value: ${{ jobs.release-please.outputs.release_created }}
+        value: ${{ jobs.release_please.outputs.release_created }}
       tag_name:
         description: "The release tag. Ex v1.4.0"
-        value: ${{ jobs.release-please.outputs.tag_name }}
+        value: ${{ jobs.release_please.outputs.tag_name }}
 
 permissions:
   contents: write
@@ -32,3 +32,13 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+
+  publish-pypi:
+    name: Publish to PyPi
+    needs: [release_please]
+    if: needs.release_please.outputs.release_created == 'true'
+    uses: ./.github/workflows/publish.yaml
+    with:
+      tag: ${{ needs.release_please.outputs.tag_name }}
+    permissions:
+      id-token: write


### PR DESCRIPTION
## Description
Use workflow_call to run publish workflow when release-please has created a new tag, as tags created by release-please are created by the github-actions[bot] bot and as such may not trigger other workflows indirectly.

# Why
*The motivation for the change (if applicable)*

# How
*How the change is implemented (if it's not self evident in the diff)*

# Dependencies
- :warning: Depends on #120 

Close: #XXX

# Checklist:
Before submitting this PR, please make sure:

- [ ] I am complying with the [contributing](https://equinor.github.io/completor/contribution_guide) doc
- [ ] My code builds clean without any errors or warnings
- [ ] I have added/extended tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation, and it builds correctly
