### PR TITLE
fix: Handle pandas deprecation warnings

### DIFF
--- a/completor/completion.py
+++ b/completor/completion.py
@@ -622,6 +622,7 @@ def connect_cells_to_segments(
     Returns:
         Merged DataFrame.
     """
+    df_well = df_well.copy()
     # Calculate mid cell measured depth
     df_reservoir[Headers.MEASURED_DEPTH] = (
         df_reservoir[Headers.START_MEASURED_DEPTH] + df_reservoir[Headers.END_MEASURED_DEPTH]
@@ -630,7 +631,7 @@ def connect_cells_to_segments(
         # Ensure that tubing segment boundaries as described in the case file are honored.
         # Associate reservoir cells with tubing segment midpoints using markers.
         df_reservoir[Headers.MARKER] = np.full(df_reservoir.shape[0], 0)
-        df_well[Headers.MARKER] = np.arange(df_well.shape[0]) + 1
+        df_well.loc[:, Headers.MARKER] = np.arange(df_well.shape[0]) + 1
 
         start_measured_depths = df_tubing_segments[Headers.START_MEASURED_DEPTH]
         end_measured_depths = df_tubing_segments[Headers.END_MEASURED_DEPTH]

--- a/completor/parse.py
+++ b/completor/parse.py
@@ -585,9 +585,7 @@ def remove_string_characters(df: pd.DataFrame | str, columns: list[str] | None =
             iterator = [] if columns is None else columns
         for column in iterator:
             try:
-                df.iloc[:, column] = remove_quotes(df.iloc[:, column].str)
-            except ValueError:
-                df[column] = remove_quotes(df[column].str)
+                df.isetitem(column, remove_quotes(df.iloc[:, column].str))
             except AttributeError:
                 # Some dataframes contains numeric data, which we ignore
                 pass


### PR DESCRIPTION
## Description
*Include a description of the change done*

Resolve deprecation warnings in Pandas.
```
DeprecationWarning: In a future version, `df.iloc[:, i] = newvals` will attempt to set the values inplace instead of always setting a new array. To retain the old behavior, use either `df[df.columns[i]] = newvals` or, if columns are non-unique, `df.isetitem(i, newvals)`
```

# Why
*The motivation for the change (if applicable)*

# How
*How the change is implemented (if it's not self evident in the diff)*

Close: #XXX

# Checklist:
Before submitting this PR, please make sure:

- [x] I am complying with the [contributing](https://equinor.github.io/completor/contribution_guide) doc
- [x] My code builds clean without any errors or warnings
- [ ] I have added/extended tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation, and it builds correctly
