### PR TITLE
fix: Error when non-active wells are specified with separate WELSPECS

### DIFF
--- a/completor/create_output.py
+++ b/completor/create_output.py
@@ -229,7 +229,7 @@ def format_header(paths: tuple[str, str] | None) -> str:
     header += (
         f"-- Created by : {(getpass.getuser()).upper()}\n"
         f"-- Created at : {datetime.now().strftime('%Y %B %d %H:%M')}\n"
-        f"{'-' * 100}\n\n\n"
+        f"{'-' * 100}\n\n"
     )
     return header
 

--- a/completor/create_output.py
+++ b/completor/create_output.py
@@ -36,7 +36,7 @@ def format_output(
         Properly formatted output string ready to be written to file.
 
     """
-    output = [_format_header(paths)]
+    output = []
 
     if case.completion_table[Headers.DEVICE_TYPE].isin([Content.AUTONOMOUS_INFLOW_CONTROL_VALVE]).any():
         output.append(CORRELATION_UDQ)
@@ -210,7 +210,7 @@ def format_output(
     return "".join(output)
 
 
-def _format_header(paths: tuple[str, str] | None) -> str:
+def format_header(paths: tuple[str, str] | None) -> str:
     """Formats the header banner, with metadata.
 
     Args:

--- a/completor/main.py
+++ b/completor/main.py
@@ -204,7 +204,7 @@ def create(
                     line_number += 1
                     continue
 
-                well_name = _get_well_name(clean_lines_map, line_number)
+                well_name = _get_well_name(clean_lines_map, line_number)  # TODO: Bit sketch with more than one?
 
                 if keyword == Keywords.WELL_SPECIFICATION:
                     chunk, after_content_line_number = process_content(line_number, clean_lines_map)
@@ -218,6 +218,7 @@ def create(
                 elif keyword == Keywords.COMPLETION_DATA:
                     chunk, after_content_line_number = process_content(line_number, clean_lines_map)
                     untouched_wells = [rec for rec in chunk if rec[0] not in list(active_wells)]
+                    _non_active = {rec[0] for rec in chunk if rec[0] not in list(active_wells)}
                     schedule_data = read_schedule.handle_compdat(schedule_data, active_wells, chunk)
                     if untouched_wells:
                         # Write untouched wells back as-is.

--- a/completor/main.py
+++ b/completor/main.py
@@ -205,7 +205,8 @@ def create(
                     line_number += 1
                     continue
 
-                well_name = _get_well_name(clean_lines_map, line_number)  # TODO: Bit sketch with more than one?
+                # TODO(#164): Check that this works properly in multi-well environment.
+                well_name = _get_well_name(clean_lines_map, line_number)
 
                 if keyword == Keywords.WELL_SPECIFICATION:
                     if well_name not in list(active_wells):

--- a/completor/main.py
+++ b/completor/main.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 import completor
 from completor import create_output, parse, read_schedule, utils
 from completor.constants import Keywords
+from completor.create_output import format_header
 from completor.exceptions import CompletorError
 from completor.launch_args_parser import get_parser
 from completor.logger import handle_error_messages, logger
@@ -253,7 +254,8 @@ def create(
             else:
                 progress_bar.update(len(lines) - prev_line_number)
 
-        for i, well_name_ in enumerate(well_names):
+        output_text += "\n" + format_header(paths)
+        for i, well_name_ in tqdm(enumerate(well_names), total=len(well_names)):
             logger.debug("Writing new MSW info for well %s", well_name_)
             well = Well(well_name_, i, case, schedule_data[well_name_])
             output = create_output.format_output(well, case, figure_name, paths)

--- a/completor/main.py
+++ b/completor/main.py
@@ -256,7 +256,7 @@ def create(
         for i, well_name_ in enumerate(well_names):
             logger.debug("Writing new MSW info for well %s", well_name_)
             well = Well(well_name_, i, case, schedule_data[well_name_])
-            output = create_output.format_output(well, figure_name, paths)
+            output = create_output.format_output(well, case, figure_name, paths)
             output_text += "\n" + output
 
     except Exception as e_:

--- a/completor/read_schedule.py
+++ b/completor/read_schedule.py
@@ -416,7 +416,6 @@ def handle_compdat(
         if well_name not in schedule_data:
             if schedule_data.get(well_name) is None:
                 schedule_data[well_name] = {}
-            schedule_data[well_name][Keywords.COMPLETION_DATA] = {"__NON_ACTIVE__"}
         schedule_data[well_name][Keywords.COMPLETION_DATA] = df[df[Headers.WELL] == well_name]
         logger.debug("handle_compdat for %s", well_name)
     return schedule_data

--- a/completor/wells.py
+++ b/completor/wells.py
@@ -122,6 +122,8 @@ class Lateral:
         self.df_device = pd.DataFrame()
 
         self.df_reservoir = self._select_well(well_name, well_data, lateral_number)
+        if self.df_reservoir.empty:
+            print("")
         self.df_measured_true_vertical_depth = completion.well_trajectory(
             self.df_welsegs_header, self.df_welsegs_content
         )

--- a/completor/wells.py
+++ b/completor/wells.py
@@ -17,7 +17,6 @@ class Well:
     Attributes:
         well_name: The name of the well.
         well_number: The number of the well.
-        case: Case file data.
         lateral_numbers: Numbers for each lateral.
         active_laterals: List of laterals.
         df_well_all_laterals: DataFrame containing all the laterals' well-layer data.
@@ -28,7 +27,6 @@ class Well:
 
     well_name: str
     well_number: int
-    case: ReadCasefile
     df_well_all_laterals: pd.DataFrame
     df_reservoir_all_laterals: pd.DataFrame
     lateral_numbers: npt.NDArray[np.int64]
@@ -45,10 +43,9 @@ class Well:
             well_data: Data from schedule file.
         """
         self.well_name = well_name
-        self.case: ReadCasefile = case
         self.well_number = well_number
 
-        lateral_numbers = self._get_active_laterals(well_name, self.case.completion_table)
+        lateral_numbers = self._get_active_laterals(well_name, case.completion_table)
         self.active_laterals = [Lateral(num, well_name, case, well_data) for num in lateral_numbers]
 
         self.df_well_all_laterals = pd.DataFrame()


### PR DESCRIPTION
## Description
*Include a description of the change done*
- Fix issue where Completor only read the first record of WELSPECS, creating errors when the subsection of active wells were not found in that record.
- Ensure only active well's COMPLETION data is read.
- Ensure 'output from completor' banner only appears once.

- Move general case out of Wells since it's common for all the wells.

# Why
*The motivation for the change (if applicable)*
They were bugs, creating problems in some cases.

# How
*How the change is implemented (if it's not self evident in the diff)*

Close: #XXX

# Checklist:
Before submitting this PR, please make sure:

- [x] I am complying with the [contributing](https://equinor.github.io/completor/contribution_guide) doc
- [x] My code builds clean without any errors or warnings
- [x] I have added/extended tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation, and it builds correctly
