### PR TITLE
chore: Migrate to `importlib`

### DIFF
--- a/completor/hook_implementations/jobs.py
+++ b/completor/hook_implementations/jobs.py
@@ -1,3 +1,4 @@
+from importlib.resources import files
 from pathlib import Path
 
 from completor.logger import logger
@@ -15,7 +16,7 @@ except ModuleNotFoundError:
 @hook_implementation
 @plugin_response(plugin_name="completor")  # type: ignore
 def installable_jobs():
-    config_file = Path("completor", "config_jobs/run_completor")
+    config_file = Path(files("completor") / "config_jobs/run_completor")
     return {config_file.name: config_file}
 
 

--- a/completor/hook_implementations/jobs.py
+++ b/completor/hook_implementations/jobs.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-from pkg_resources import resource_filename
-
 from completor.logger import logger
 
 SKIP_TESTS = False
@@ -17,7 +15,7 @@ except ModuleNotFoundError:
 @hook_implementation
 @plugin_response(plugin_name="completor")  # type: ignore
 def installable_jobs():
-    config_file = Path(resource_filename("completor", "config_jobs/run_completor"))
+    config_file = Path("completor", "config_jobs/run_completor")
     return {config_file.name: config_file}
 
 


### PR DESCRIPTION
## Description
Migrate from `pkg_resources` to `importlib`.

# Why
Since python 3.12 `pkg_resources` is no longer included in python by default.

# How
Use `importlib.resources.files` insted.

Close: #170 

# Checklist:
Before submitting this PR, please make sure:

- [ ] I am complying with the [contributing](https://equinor.github.io/completor/contribution_guide) doc
- [ ] My code builds clean without any errors or warnings
- [ ] I have added/extended tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation, and it builds correctly
