### PR TITLE
feat: Make completor compatible with Pandas 2.1.4

### DIFF
--- a/completor/main.py
+++ b/completor/main.py
@@ -27,8 +27,6 @@ from completor.utils import (
 )
 from completor.wells import Well
 
-pd.set_option("future.no_silent_downcasting", True)
-
 
 def get_content_and_path(case_content: str, file_path: str | None, keyword: str) -> tuple[str | None, str | None]:
     """Get the contents of a file from a path defined by user or case file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 python = ">=3.11, <3.12"
 matplotlib = "^3.9.2"
 numpy = "<2.0.0"
-pandas = "^2.2.3"
+pandas = "^2.1.4"
 scipy = "^1.14.1"
 tqdm = "^4.66.5"
 pytest-env = "^1.1.4"


### PR DESCRIPTION
## Description

Removed a setting that only works in Pandas 2.2

# Why

Need compatibility with Pandas 2.1 as another tool in Komodo has exposed a serious flaw with Pandas 2.2.

# How

Close: #XXX

# Checklist:
Before submitting this PR, please make sure:

- [ ] I am complying with the [contributing](https://equinor.github.io/completor/contribution_guide) doc
- [x] My code builds clean without any errors or warnings
- [ ] I have added/extended tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation, and it builds correctly
