### PR TITLE
fix: Similar well name is mixed while replacing schedule files

### DIFF
--- a/completor/utils.py
+++ b/completor/utils.py
@@ -338,7 +338,7 @@ def find_well_keyword_data(well: str, keyword: str, text: str) -> str:
                 if once:
                     lines.append(line)
                 continue
-            if well == line.split()[0].strip("'\""):
+            if well == line.split()[0].replace("'", "").replace('"', ""):
                 if keyword in [Keywords.WELL_SEGMENTS, Keywords.COMPLETION_SEGMENTS]:
                     # These keywords should just be the entire match as they never contain more than one well.
                     return match

--- a/completor/utils.py
+++ b/completor/utils.py
@@ -338,7 +338,7 @@ def find_well_keyword_data(well: str, keyword: str, text: str) -> str:
                 if once:
                     lines.append(line)
                 continue
-            if well in line.split()[0]:
+            if well == line.split()[0].strip("'\""):
                 if keyword in [Keywords.WELL_SEGMENTS, Keywords.COMPLETION_SEGMENTS]:
                     # These keywords should just be the entire match as they never contain more than one well.
                     return match


### PR DESCRIPTION
## Description
The method find_well_keyword is mixing long well names as it is stated as `in` instead of `==`

# Why
This will create error on later similar well name

# How
Make strip more strict

Close: #XXX

# Checklist:
Before submitting this PR, please make sure:

- [x] I am complying with the [contributing](https://equinor.github.io/completor/contribution_guide) doc
- [x] My code builds clean without any errors or warnings
- [x] I have added/extended tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation, and it builds correctly
