### PR TITLE
fix: Update numpy and pandas warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ dist
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+.vscode
 
 # yarn v2
 .yarn/cache

--- a/completor/input_validation.py
+++ b/completor/input_validation.py
@@ -8,6 +8,8 @@ import pandas as pd
 from completor.constants import Content, Headers
 from completor.exceptions.clean_exceptions import CompletorError
 
+pd.set_option("future.no_silent_downcasting", True)
+
 
 def set_default_packer_section(df_comp: pd.DataFrame) -> pd.DataFrame:
     """Set the default value for the packer section.

--- a/completor/parse.py
+++ b/completor/parse.py
@@ -338,8 +338,8 @@ def get_welsegs_table(collections: list[ContentCollection]) -> tuple[pd.DataFram
             try:
                 header_table: npt.NDArray[np.unicode_] | pd.DataFrame
                 record_table: npt.NDArray[np.unicode_] | pd.DataFrame
-                header_table = np.row_stack((header_table, header_collection))
-                record_table = np.row_stack((record_table, record_collection))
+                header_table = np.vstack((header_table, header_collection))
+                record_table = np.vstack((record_table, record_collection))
             except NameError:
                 # First iteration
                 header_table = np.asarray(header_collection)
@@ -394,7 +394,7 @@ def get_welspecs_table(collections: list[ContentCollection]) -> pd.DataFrame:
             if welspecs_table is None:
                 welspecs_table = np.copy(the_collection)
             else:
-                welspecs_table = np.row_stack((welspecs_table, the_collection))
+                welspecs_table = np.vstack((welspecs_table, the_collection))
 
     if welspecs_table is None:
         raise ValueError(f"Collection does not contain the '{Keywords.WELL_SPECIFICATION}' keyword")
@@ -424,7 +424,7 @@ def get_compdat_table(collections: list[ContentCollection]) -> pd.DataFrame:
             if compdat_table is None:
                 compdat_table = np.copy(the_collection)
             else:
-                compdat_table = np.row_stack((compdat_table, the_collection))
+                compdat_table = np.vstack((compdat_table, the_collection))
     if compdat_table is None:
         raise ValueError(f"Collection does not contain the '{Keywords.COMPLETION_DATA}' keyword")
     compdat_table = pd.DataFrame(
@@ -472,7 +472,7 @@ def get_compsegs_table(collections: list[ContentCollection]) -> pd.DataFrame:
             if compsegs_table is None:
                 compsegs_table = np.copy(the_collection)
             else:
-                compsegs_table = np.row_stack((compsegs_table, the_collection))
+                compsegs_table = np.vstack((compsegs_table, the_collection))
 
     if compsegs_table is None:
         raise ValueError(f"Collection does not contain the '{Keywords.COMPLETION_SEGMENTS}' keyword")

--- a/completor/utils.py
+++ b/completor/utils.py
@@ -234,7 +234,7 @@ def check_width_lines(result: str, limit: int) -> list[tuple[int, str]]:
         cleaned_line = cleaned_line.rsplit("--")[0]
 
         if len(cleaned_line) > limit:
-            too_long_lines.append((line_index, lines[line_index]))
+            too_long_lines.append((int(line_index), lines[line_index]))
     return too_long_lines
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,5 +80,8 @@ max_line_length="132"
 ignore="E203, W503, E704"
 
 [tool.pytest.ini_options]
-markers = ["integration: mark a test as an integration test."]
+markers = [
+    "integration: mark a test as an integration test.",
+    "requires_ert: Mark tests that require ERT (Ensemble Reservoir Tool)."
+]
 env = ["TQDM_DISABLE=1"]


### PR DESCRIPTION
## Description
numpy needs to be redefined as int(), preventing to print as np.int(xx)
pandas has some future warning



Close: #XXX

# Checklist:
Before submitting this PR, please make sure:

- [x] I am complying with the [contributing](https://equinor.github.io/completor/contribution_guide) doc
- [x] My code builds clean without any errors or warnings
- [x] I have added/extended tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation, and it builds correctly
